### PR TITLE
Fix - Unlock secret collection before start

### DIFF
--- a/src/Helpers/SecretManager.vala
+++ b/src/Helpers/SecretManager.vala
@@ -93,6 +93,12 @@ public class Alohomora.SecretManager: GLib.Object {
                 );
             }
             else {
+                if(collection.get_locked ()) {
+                    var objects = new GLib.List<GLib.DBusProxy>();
+		            objects.prepend(collection);
+		            GLib.List<GLib.DBusProxy> unlocked;
+		            yield service.unlock (objects, null, out unlocked);
+                }
                 yield load_secrets();
             }
             initialized ();


### PR DESCRIPTION
Checks whether the secret collection is locked before loading secrets. If locked, it unlocks the collection and proceeds as usual.